### PR TITLE
Add simple A/B testing on homepage

### DIFF
--- a/assets/js/ab-test.js
+++ b/assets/js/ab-test.js
@@ -1,0 +1,20 @@
+(function () {
+  var variant = localStorage.getItem('ab-homepage');
+  if (!variant) {
+    variant = Math.random() < 0.5 ? 'A' : 'B';
+    localStorage.setItem('ab-homepage', variant);
+  }
+  document.documentElement.setAttribute('data-ab-variant', variant);
+  if (variant === 'B') {
+    var hero = document.querySelector('.hero-inner');
+    if (!hero) return;
+    var heading = hero.querySelector('h1');
+    var desc = hero.querySelector('p');
+    if (heading) {
+      heading.textContent = 'Build cashflow with Nyuton Enterprises';
+    }
+    if (desc) {
+      desc.innerHTML = 'From <strong>vending</strong> to <strong>cybersecurity</strong>, we turn ideas into revenue — fast.';
+    }
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <link rel="icon" href="/assets/img/logo.svg" type="image/svg+xml" />
 <link rel="preload" href="/assets/img/hero.svg" as="image" />
 <link rel="stylesheet" href="/assets/css/style.css" />
+<script defer src="/assets/js/ab-test.js"></script>
 <script defer src="/assets/js/main.js"></script>
 
 </head>


### PR DESCRIPTION
## Summary
- introduce lightweight A/B test script that toggles hero copy
- hook A/B test into homepage template

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abd09ff8248327a67497e42c559ef4