### PR TITLE
Add service-specific pages and update footer links

### DIFF
--- a/about.html
+++ b/about.html
@@ -47,10 +47,10 @@
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
     <div class="list" style="margin-top:.6rem">
       <span class="badge">Raleigh • Durham • Garner</span>
-      <span class="badge">Vending</span>
-      <span class="badge">Gaming</span>
-      <span class="badge">Cybersecurity</span>
-      <span class="badge">Online Ads</span>
+      <a class="badge" href="/vending.html">Vending</a>
+      <a class="badge" href="/gaming.html">Gaming</a>
+      <a class="badge" href="/cybersecurity.html">Cybersecurity</a>
+      <a class="badge" href="/online-ads.html">Online Ads</a>
     </div>
   </div>
 </footer>

--- a/contact.html
+++ b/contact.html
@@ -62,10 +62,10 @@
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
     <div class="list" style="margin-top:.6rem">
       <span class="badge">Raleigh • Durham • Garner</span>
-      <span class="badge">Vending</span>
-      <span class="badge">Gaming</span>
-      <span class="badge">Cybersecurity</span>
-      <span class="badge">Online Ads</span>
+      <a class="badge" href="/vending.html">Vending</a>
+      <a class="badge" href="/gaming.html">Gaming</a>
+      <a class="badge" href="/cybersecurity.html">Cybersecurity</a>
+      <a class="badge" href="/online-ads.html">Online Ads</a>
     </div>
   </div>
 </footer>

--- a/cybersecurity.html
+++ b/cybersecurity.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Not found — Nyuton Enterprises</title>
-  
+  <title>Cybersecurity — Nyuton Enterprises</title>
+
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="color-scheme" content="dark light" />
@@ -14,7 +14,7 @@
 
 </head>
 <body>
-  
+
 <nav class="nav" aria-label="Primary navigation">
   <div class="container nav-inner">
     <a class="logo" href="/"><img src="/assets/img/logo.svg" alt="Nyuton Enterprises logo" /><strong>Nyuton</strong></a>
@@ -29,10 +29,18 @@
 </nav>
 
   <main class="container section">
-    <h1>Page not found</h1>
-    <p>Try the <a href="/">home page</a> or <a href="/contact.html">contact us</a>.</p>
+    <h1>Cybersecurity</h1>
+    <p>Pragmatic security for small orgs. Policies, training, and protections that don’t slow you down.</p>
+    <ul class="list">
+      <li>Risk & compliance (HIPAA/CARF aware)</li>
+      <li>Device hardening & backups</li>
+      <li>Incident response runbooks</li>
+    </ul>
+    <p style="margin-top:1.2rem">
+      <a class="btn" href="/contact.html">Upgrade security</a>
+    </p>
   </main>
-  
+
 <footer class="footer">
   <div class="container">
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
@@ -48,3 +56,4 @@
 
 </body>
 </html>
+

--- a/gaming.html
+++ b/gaming.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Not found — Nyuton Enterprises</title>
-  
+  <title>Gaming & Interactive — Nyuton Enterprises</title>
+
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="color-scheme" content="dark light" />
@@ -14,7 +14,7 @@
 
 </head>
 <body>
-  
+
 <nav class="nav" aria-label="Primary navigation">
   <div class="container nav-inner">
     <a class="logo" href="/"><img src="/assets/img/logo.svg" alt="Nyuton Enterprises logo" /><strong>Nyuton</strong></a>
@@ -29,10 +29,18 @@
 </nav>
 
   <main class="container section">
-    <h1>Page not found</h1>
-    <p>Try the <a href="/">home page</a> or <a href="/contact.html">contact us</a>.</p>
+    <h1>Gaming & Interactive</h1>
+    <p>Original HTML5 games and brand activations. From quick plays to sticky engagement loops.</p>
+    <ul class="list">
+      <li>Web & mobile ready</li>
+      <li>Analytics & A/B testing</li>
+      <li>Licensing & white‑label</li>
+    </ul>
+    <p style="margin-top:1.2rem">
+      <a class="btn" href="/contact.html">Discuss a game</a>
+    </p>
   </main>
-  
+
 <footer class="footer">
   <div class="container">
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
@@ -48,3 +56,4 @@
 
 </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   <main class="container section">
     <section class="grid">
       <article class="card" aria-labelledby="vending">
-        <h3 id="vending">Vending & Micro‑Markets</h3>
+        <h3 id="vending"><a href="/vending.html">Vending & Micro‑Markets</a></h3>
         <p>Smart, cashless machines with product mix tuned to your traffic. We handle placement, restock, and support.</p>
         <ul class="list">
           <li>Card & mobile payments</li>
@@ -52,7 +52,7 @@
       </article>
 
       <article class="card" aria-labelledby="gaming">
-        <h3 id="gaming">Gaming & Interactive</h3>
+        <h3 id="gaming"><a href="/gaming.html">Gaming & Interactive</a></h3>
         <p>Original HTML5 games and brand activations. From quick plays to sticky engagement loops.</p>
         <ul class="list">
           <li>Web & mobile ready</li>
@@ -62,7 +62,7 @@
       </article>
 
       <article class="card" aria-labelledby="cyber">
-        <h3 id="cyber">Cybersecurity</h3>
+        <h3 id="cyber"><a href="/cybersecurity.html">Cybersecurity</a></h3>
         <p>Pragmatic security for small orgs. Policies, training, and protections that don’t slow you down.</p>
         <ul class="list">
           <li>Risk & compliance (HIPAA/CARF aware)</li>
@@ -72,7 +72,7 @@
       </article>
 
       <article class="card" aria-labelledby="ads">
-        <h3 id="ads">Online Advertising</h3>
+        <h3 id="ads"><a href="/online-ads.html">Online Advertising</a></h3>
         <p>Performance marketing with discipline. Crisp landing pages, clean data, steady iteration.</p>
         <ul class="list">
           <li>SEO/Local SEO</li>
@@ -103,10 +103,10 @@
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
     <div class="list" style="margin-top:.6rem">
       <span class="badge">Raleigh • Durham • Garner</span>
-      <span class="badge">Vending</span>
-      <span class="badge">Gaming</span>
-      <span class="badge">Cybersecurity</span>
-      <span class="badge">Online Ads</span>
+      <a class="badge" href="/vending.html">Vending</a>
+      <a class="badge" href="/gaming.html">Gaming</a>
+      <a class="badge" href="/cybersecurity.html">Cybersecurity</a>
+      <a class="badge" href="/online-ads.html">Online Ads</a>
     </div>
   </div>
 </footer>

--- a/online-ads.html
+++ b/online-ads.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Not found — Nyuton Enterprises</title>
-  
+  <title>Online Advertising — Nyuton Enterprises</title>
+
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="color-scheme" content="dark light" />
@@ -14,7 +14,7 @@
 
 </head>
 <body>
-  
+
 <nav class="nav" aria-label="Primary navigation">
   <div class="container nav-inner">
     <a class="logo" href="/"><img src="/assets/img/logo.svg" alt="Nyuton Enterprises logo" /><strong>Nyuton</strong></a>
@@ -29,10 +29,18 @@
 </nav>
 
   <main class="container section">
-    <h1>Page not found</h1>
-    <p>Try the <a href="/">home page</a> or <a href="/contact.html">contact us</a>.</p>
+    <h1>Online Advertising</h1>
+    <p>Performance marketing with discipline. Crisp landing pages, clean data, steady iteration.</p>
+    <ul class="list">
+      <li>SEO/Local SEO</li>
+      <li>Paid search & social</li>
+      <li>Conversion tracking</li>
+    </ul>
+    <p style="margin-top:1.2rem">
+      <a class="btn" href="/contact.html">Plan a campaign</a>
+    </p>
   </main>
-  
+
 <footer class="footer">
   <div class="container">
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
@@ -48,3 +56,4 @@
 
 </body>
 </html>
+

--- a/services.html
+++ b/services.html
@@ -34,19 +34,19 @@
 
     <section class="grid">
       <article class="card">
-        <h3>Vending: Site Assessment → Install → Refill</h3>
+        <h3><a href="/vending.html">Vending: Site Assessment → Install → Refill</a></h3>
         <p>We scout locations, handle permits, set up cashless payments, and keep shelves stocked.</p>
       </article>
       <article class="card">
-        <h3>Gaming: Prototypes to Production</h3>
+        <h3><a href="/gaming.html">Gaming: Prototypes to Production</a></h3>
         <p>We craft HTML5 games and engagement tools. Need a slot‑style demo? We’ve got you.</p>
       </article>
       <article class="card">
-        <h3>Cybersecurity: Baseline to Better</h3>
+        <h3><a href="/cybersecurity.html">Cybersecurity: Baseline to Better</a></h3>
         <p>Device hardening, backup strategy, MFA rollouts, policy packs — right‑sized for SMBs.</p>
       </article>
       <article class="card">
-        <h3>Online Ads: From Clicks to Clients</h3>
+        <h3><a href="/online-ads.html">Online Ads: From Clicks to Clients</a></h3>
         <p>Landing pages, lead forms, and analytics that actually connect to revenue.</p>
       </article>
     </section>
@@ -61,10 +61,10 @@
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
     <div class="list" style="margin-top:.6rem">
       <span class="badge">Raleigh • Durham • Garner</span>
-      <span class="badge">Vending</span>
-      <span class="badge">Gaming</span>
-      <span class="badge">Cybersecurity</span>
-      <span class="badge">Online Ads</span>
+      <a class="badge" href="/vending.html">Vending</a>
+      <a class="badge" href="/gaming.html">Gaming</a>
+      <a class="badge" href="/cybersecurity.html">Cybersecurity</a>
+      <a class="badge" href="/online-ads.html">Online Ads</a>
     </div>
   </div>
 </footer>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,4 +4,8 @@
   <url><loc>https://nyutonenterprises.com/services.html</loc></url>
   <url><loc>https://nyutonenterprises.com/about.html</loc></url>
   <url><loc>https://nyutonenterprises.com/contact.html</loc></url>
+  <url><loc>https://nyutonenterprises.com/vending.html</loc></url>
+  <url><loc>https://nyutonenterprises.com/gaming.html</loc></url>
+  <url><loc>https://nyutonenterprises.com/cybersecurity.html</loc></url>
+  <url><loc>https://nyutonenterprises.com/online-ads.html</loc></url>
 </urlset>

--- a/vending.html
+++ b/vending.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>Not found — Nyuton Enterprises</title>
-  
+  <title>Vending & Micro‑Markets — Nyuton Enterprises</title>
+
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="color-scheme" content="dark light" />
@@ -14,7 +14,7 @@
 
 </head>
 <body>
-  
+
 <nav class="nav" aria-label="Primary navigation">
   <div class="container nav-inner">
     <a class="logo" href="/"><img src="/assets/img/logo.svg" alt="Nyuton Enterprises logo" /><strong>Nyuton</strong></a>
@@ -29,10 +29,18 @@
 </nav>
 
   <main class="container section">
-    <h1>Page not found</h1>
-    <p>Try the <a href="/">home page</a> or <a href="/contact.html">contact us</a>.</p>
+    <h1>Vending & Micro‑Markets</h1>
+    <p>Smart, cashless machines with product mix tuned to your traffic. We handle placement, restock, and support.</p>
+    <ul class="list">
+      <li>Card & mobile payments</li>
+      <li>Healthy snacks + local favorites</li>
+      <li>24/7 monitoring & refill</li>
+    </ul>
+    <p style="margin-top:1.2rem">
+      <a class="btn" href="/contact.html">Request vending</a>
+    </p>
   </main>
-  
+
 <footer class="footer">
   <div class="container">
     <div>© 2025 Nyuton Enterprises LLC — All rights reserved.</div>
@@ -48,3 +56,4 @@
 
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Link footer badges to dedicated service pages for Vending, Gaming, Cybersecurity, and Online Ads
- Create standalone pages for each service with brief descriptions and calls to action
- Wire service overview and sitemap to the new pages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abd0c9aa7c8327bd9336cb2765d1a6